### PR TITLE
Add partnerships section to homepage

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -4,6 +4,7 @@ import TrainingPromoSection from '@/components/sections/TrainingPromoSection';
 import TestimonialsSection from '@/components/sections/TestimonialsSection';
 import AboutSection from '@/components/sections/AboutSection';
 import CallToActionSection from '@/components/sections/CallToActionSection';
+import PartnershipsSection from '@/components/sections/PartnershipsSection';
 
 export default function HomePage() {
   return (
@@ -11,8 +12,9 @@ export default function HomePage() {
       <HeroSection />
       <AboutSection />
       <FeaturedServicesSection />
-      <TrainingPromoSection />
+      <PartnershipsSection />
       <TestimonialsSection />
+      <TrainingPromoSection />
       <CallToActionSection />
     </>
   );

--- a/src/components/sections/PartnershipsSection.tsx
+++ b/src/components/sections/PartnershipsSection.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+
+export default function PartnershipsSection() {
+  return (
+    <section className="relative w-full py-20">
+      {/* Background Image */}
+      <div className="absolute inset-0">
+        <Image
+          src="/images/partnerships-banner.jpg"
+          alt="Partnerships and Community"
+          fill
+          className="object-cover opacity-80"
+          priority
+          sizes="100vw"
+        />
+        <div className="absolute inset-0 bg-black/50" />
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 max-w-4xl mx-auto text-center px-6">
+        <h2 className="text-4xl md:text-5xl font-bold text-white mb-6">
+          Partnerships &amp; Community
+        </h2>
+        <p className="text-lg md:text-xl text-gray-200 mb-8">
+          From Alphaland to Summer Shredding and Muscle Beach, Viva La Beauty is proud
+          to support the bodybuilding and fitness community. Our partnerships reflect
+          our passion for beauty, strength, and confidence.
+        </p>
+        <Button
+          asChild
+          size="lg"
+          className="bg-primary text-white hover:bg-primary/90"
+        >
+          <a href="/partnerships">See Our Partnerships</a>
+        </Button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Partnerships & Community section component with a banner image overlay and CTA
- insert the partnerships section on the homepage between the featured services and testimonials sections

## Testing
- npm run lint *(fails: prompts for ESLint configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b6325bdc83329933f40a3137cc16