### PR TITLE
Add Houston's Best logo to hero section

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -40,6 +40,16 @@ export default function HeroSection() {
           </Button>
         </div>
       </div>
+      <div className="absolute bottom-4 left-4 z-20">
+        <Image
+          src="https://static.wixstatic.com/media/285fa5_0b0d21708449487b8104e8d671332e56~mv2.png/v1/fill/w_610,h_304,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/houstonsbest.png"
+          alt="Houston's Best logo"
+          width={180}
+          height={90}
+          className="h-auto w-[140px] sm:w-[160px] md:w-[180px]"
+          priority
+        />
+      </div>
       <style jsx>{`
         @keyframes fade-in-down {
           0% {


### PR DESCRIPTION
### Motivation
- Add the Houston's Best badge to the home page hero and position it at the bottom-left of the HERO area as a requested visual element.

### Description
- Inserted an absolutely positioned `Image` in `src/components/sections/HeroSection.tsx` at `bottom-4 left-4` with the provided remote `static.wixstatic.com` URL, responsive `width`/`height` and `priority` set for immediate loading.

### Testing
- Started the app with `npm run dev` and ran a Playwright script to capture a visual verification screenshot saved at `artifacts/hero-logo.png`; the dev server compiled and served `/` (200) and the screenshot shows the logo, while Next.js image proxy requests returned 500s due to network unreachable errors unrelated to the DOM change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826ead94ec8332bb381eca74694fcd)